### PR TITLE
Fixes #60. Changes type of country baton's ipnum

### DIFF
--- a/src/country.h
+++ b/src/country.h
@@ -52,7 +52,7 @@ struct country_baton_t {
   geoip::Country *c;
   //char host_cstr[256];
   int country_id;
-  int ipnum;  // uint32_t?
+  uint32_t ipnum;
   Persistent<Function> cb;
 };
 

--- a/test/country.mocha.js
+++ b/test/country.mocha.js
@@ -70,6 +70,16 @@ describe('Country', function() {
         setTimeout(done, 1);
       });
     });
+
+    it('lookupSync method should return the same result as lookup method', function(done) {
+      var country = instance.lookupSync('134.191.232.69');
+      instance.lookup('134.191.232.69', function (err, data) {
+        should.not.exist(err);
+        should.exist(data);
+        data.country_code.should.equal(country.country_code);
+        setTimeout(done, 1);
+      });
+    });
   });
 
   describe('Update database on the fly', function() {


### PR DESCRIPTION
Previous type of country_baton_t::ipnum was int It was overflowing
causing Country::lookupSync to return error. It has been changed to
int32_t.
