### PR TITLE
Type-check ip addresses/domains

### DIFF
--- a/lib/city.js
+++ b/lib/city.js
@@ -43,7 +43,8 @@ function City(file, options) {
 City.prototype.lookup = function(ipORdomain, callback) {
     var self = this;
 
-    helper.validateIpORdomain(ipORdomain);
+    if(helper.validateIpORdomain(ipORdomain))
+        return callback.call(self, new TypeError('expected string'));
 
     dns.lookup(ipORdomain, 4, function(err, address, family) {
         if (err) {
@@ -64,7 +65,7 @@ City.prototype.lookup = function(ipORdomain, callback) {
  * @param {String} ipORdomain
  */
 City.prototype.lookupSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);
+    helper.validateIpORdomainSync(ipORdomain);
 
     return this.native.lookupSync(ipORdomain);
 };

--- a/lib/city6.js
+++ b/lib/city6.js
@@ -43,7 +43,8 @@ function City6(file, options) {
 City6.prototype.lookup = function(ipORdomain, callback) {
     var self = this;
 
-    helper.validateIpORdomain(ipORdomain);
+    if(helper.validateIpORdomain(ipORdomain))
+        return callback.call(self, new TypeError('expected string'));
 
     dns.lookup(ipORdomain, 6, function(err, address, family) {
         if (err) {
@@ -64,7 +65,7 @@ City6.prototype.lookup = function(ipORdomain, callback) {
  * @param {String} ipORdomain
  */
 City6.prototype.lookupSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);
+    helper.validateIpORdomainSync(ipORdomain);
 
     return this.native.lookupSync(ipORdomain);
 };

--- a/lib/country.js
+++ b/lib/country.js
@@ -42,8 +42,9 @@ function Country(file, options) {
  */
 Country.prototype.lookup = function(ipORdomain, callback) {
     var self = this;
-
-    helper.validateIpORdomain(ipORdomain);    
+    
+    if(helper.validateIpORdomain(ipORdomain))
+        return callback.call(self, new TypeError('expected string'));
 
     dns.lookup(ipORdomain, 4, function(err, address, family) {
         if (err) {
@@ -64,7 +65,7 @@ Country.prototype.lookup = function(ipORdomain, callback) {
  * @param {String} ipORdomain
  */
 Country.prototype.lookupSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);
+    helper.validateIpORdomainSync(ipORdomain);
 
     return this.native.lookupSync(ipORdomain);
 };

--- a/lib/country6.js
+++ b/lib/country6.js
@@ -43,7 +43,8 @@ function Country6(file, options) {
 Country6.prototype.lookup = function(ipORdomain, callback) {
     var self = this;
 
-    helper.validateIpORdomain(ipORdomain);
+    if(helper.validateIpORdomain(ipORdomain))
+        return callback.call(self, new TypeError('expected string'));
 
     dns.lookup(ipORdomain, 6, function(err, address, family) {
         if (err) {
@@ -64,7 +65,7 @@ Country6.prototype.lookup = function(ipORdomain, callback) {
  * @param {String} ipORdomain
  */
 Country6.prototype.lookupSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);
+    helper.validateIpORdomainSync(ipORdomain);
 
     return this.native.lookupSync(ipORdomain);
 };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -43,7 +43,11 @@ exports.validateFile = function(file, types) {
 }
 
 exports.validateIpORdomain = function(ipORdomain) {
+    return typeof ipORdomain != 'string';
+}
+
+exports.validateIpORdomainSync = function(ipORdomain) {
     if (typeof ipORdomain != 'string') {
-        throw new TypeError('ipORdomain must be a string');
+        throw new TypeError('expected string');
     }
 }

--- a/lib/netspeed.js
+++ b/lib/netspeed.js
@@ -43,7 +43,8 @@ function NetSpeed(file, options) {
 NetSpeed.prototype.lookup = function(ipORdomain, callback) {
     var self = this;
 
-    helper.validateIpORdomain(ipORdomain);
+    if(helper.validateIpORdomain(ipORdomain))
+        return callback.call(self, new TypeError('expected string'));
 
     dns.lookup(ipORdomain, 4, function(err, address, family) {
         if (err) {
@@ -64,12 +65,12 @@ NetSpeed.prototype.lookup = function(ipORdomain, callback) {
  * @param {String} ipORdomain
  */
 NetSpeed.prototype.lookupSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);    
+    helper.validateIpORdomainSync(ipORdomain);    
     return this.native.lookupSync(ipORdomain);
 };
 
 NetSpeed.prototype.lookupCellularSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);    
+    helper.validateIpORdomainSync(ipORdomain);    
     return this.native.lookupCellularSync(ipORdomain);
 }; 
 

--- a/lib/netspeedcell.js
+++ b/lib/netspeedcell.js
@@ -43,7 +43,8 @@ function NetSpeedCell(file, options) {
 NetSpeedCell.prototype.lookup = function(ipORdomain, callback) {
     var self = this;
 
-    helper.validateIpORdomain(ipORdomain);
+    if(helper.validateIpORdomain(ipORdomain))
+        return callback.call(self, new TypeError('expected string'));
 
     dns.lookup(ipORdomain, 4, function(err, address, family) {
         if (err) {
@@ -64,7 +65,7 @@ NetSpeedCell.prototype.lookup = function(ipORdomain, callback) {
  * @param {String} ipORdomain
  */
 NetSpeedCell.prototype.lookupSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);
+    helper.validateIpORdomainSync(ipORdomain);
         
     return this.native.lookupSync(ipORdomain);
 };

--- a/lib/org.js
+++ b/lib/org.js
@@ -43,7 +43,8 @@ function Org(file, options) {
 Org.prototype.lookup = function(ipORdomain, callback) {
     var self = this;
 
-    helper.validateIpORdomain(ipORdomain);
+    if(helper.validateIpORdomain(ipORdomain))
+        return callback.call(self, new TypeError('expected string'));
 
     dns.lookup(ipORdomain, 4, function(err, address, family) {
         if (err) {
@@ -64,7 +65,7 @@ Org.prototype.lookup = function(ipORdomain, callback) {
  * @param {String} ipORdomain
  */
 Org.prototype.lookupSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);    
+    helper.validateIpORdomainSync(ipORdomain);    
     return this.native.lookupSync(ipORdomain);
 };
 

--- a/lib/region.js
+++ b/lib/region.js
@@ -43,7 +43,8 @@ function Region(file, options) {
 Region.prototype.lookup = function(ipORdomain, callback) {
     var self = this;
 
-    helper.validateIpORdomain(ipORdomain);
+    if(helper.validateIpORdomain(ipORdomain))
+        return callback.call(self, new TypeError('expected string'));
 
     dns.lookup(ipORdomain, 4, function(err, address, family) {
         if (err) {
@@ -64,7 +65,7 @@ Region.prototype.lookup = function(ipORdomain, callback) {
  * @param {String} ipORdomain
  */
 Region.prototype.lookupSync = function(ipORdomain) {
-    helper.validateIpORdomain(ipORdomain);
+    helper.validateIpORdomainSync(ipORdomain);
 
     return this.native.lookupSync(ipORdomain);
 };


### PR DESCRIPTION
If you pass the incorret type, an assertion will fail in the native extension,
causing your node.js process to die (theres no way to catch this error!). Now
ip addresses are typechecked in js before being passed to native.
