### PR TITLE
Support for binary deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ install: install_memwatch
 install_memwatch:
 	@NODE_ENV=development bash ./cli/install_memwatch.sh
 rebuild: install
-	@NODE_ENV=development node-gyp rebuild
+	@NODE_ENV=development ./node_modules/.bin/node-pre-gyp clean rebuild
 bootstrap: install
 	@NODE_ENV=development sh ./cli/bootstrap.sh
 mem_test: install rebuild bootstrap

--- a/benchmark/test.js
+++ b/benchmark/test.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var assert = require('assert');
-var binding = require('../build/default/geoip.node');
+var binding = require('../lib/native');
 var util = require('util');
 var Test = binding.Test;
 var c = new Test('../database/GeoLiteCity.dat', true);

--- a/binding.gyp
+++ b/binding.gyp
@@ -34,5 +34,16 @@
         }]
       ]
     },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "native" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/native.node" ],
+          "destination": "./lib/binding/"
+        }
+      ]
+    }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var path  = require('path'),
     read  = require('fs').readFileSync;
 
-var binding = require('bindings')('native.node');
-
 var version  = JSON.parse(read(path.resolve(__dirname, './package.json'))).version;
+
+var binding = require('./lib/native');
 
 // Native classes
 exports.native = binding;

--- a/lib/city.js
+++ b/lib/city.js
@@ -10,7 +10,7 @@ var isObject = require('is-object');
 var info = require('debug')('geoip:lib:city:info');
 var debug = require('debug')('geoip:lib:city:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 var validateFile = require('./helpers').validateFile;
 var isValidIpORdomain = require('./helpers').isValidIpORdomain;

--- a/lib/city6.js
+++ b/lib/city6.js
@@ -10,7 +10,7 @@ var isObject = require('is-object');
 var info = require('debug')('geoip:lib:city6:info');
 var debug = require('debug')('geoip:lib:city6:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 var validateFile = require('./helpers').validateFile;
 var isValidIpORdomain = require('./helpers').isValidIpORdomain;

--- a/lib/country.js
+++ b/lib/country.js
@@ -10,7 +10,7 @@ var isObject = require('is-object');
 var info = require('debug')('geoip:lib:country:info');
 var debug = require('debug')('geoip:lib:country:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 var validateFile = require('./helpers').validateFile;
 var isValidIpORdomain = require('./helpers').isValidIpORdomain;

--- a/lib/country6.js
+++ b/lib/country6.js
@@ -10,7 +10,7 @@ var isObject = require('is-object');
 var info = require('debug')('geoip:lib:country:info');
 var debug = require('debug')('geoip:lib:country:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 var validateFile = require('./helpers').validateFile;
 var isValidIpORdomain = require('./helpers').isValidIpORdomain;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,7 +10,7 @@ var util = require('util');
 var info = require('debug')('geoip:lib:helper:info');
 var debug = require('debug')('geoip:lib:helper:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 exports.validateFile = function(file, types) {
     var err;

--- a/lib/native.js
+++ b/lib/native.js
@@ -1,0 +1,4 @@
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
+module.exports = require(binding_path);

--- a/lib/netspeed.js
+++ b/lib/netspeed.js
@@ -10,7 +10,7 @@ var isObject = require('is-object');
 var info = require('debug')('geoip:lib:netSpeed:info');
 var debug = require('debug')('geoip:lib:netSpeed:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 var validateFile = require('./helpers').validateFile;
 var isValidIpORdomain = require('./helpers').isValidIpORdomain;

--- a/lib/netspeedcell.js
+++ b/lib/netspeedcell.js
@@ -10,7 +10,7 @@ var isObject = require('is-object');
 var info = require('debug')('geoip:lib:netspeedcell:info');
 var debug = require('debug')('geoip:lib:netspeedcell:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 var validateFile = require('./helpers').validateFile;
 var isValidIpORdomain = require('./helpers').isValidIpORdomain;

--- a/lib/org.js
+++ b/lib/org.js
@@ -10,7 +10,7 @@ var isObject = require('is-object');
 var info = require('debug')('geoip:lib:org:info');
 var debug = require('debug')('geoip:lib:org:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 var validateFile = require('./helpers').validateFile;
 var isValidIpORdomain = require('./helpers').isValidIpORdomain;

--- a/lib/region.js
+++ b/lib/region.js
@@ -10,7 +10,7 @@ var isObject = require('is-object');
 var info = require('debug')('geoip:lib:region:info');
 var debug = require('debug')('geoip:lib:region:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 var validateFile = require('./helpers').validateFile;
 var isValidIpORdomain = require('./helpers').isValidIpORdomain;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,6 @@ var path  = require('path');
 var info = require('debug')('geoip:lib:util:info');
 var debug = require('debug')('geoip:lib:util:debug');
 
-var binding = require('bindings')('native.node');
+var binding = require('./native');
 
 exports = {};

--- a/package.json
+++ b/package.json
@@ -26,15 +26,17 @@
     "Nicolas Fouché <nicolas.fouche@gmail.com>"
   ],
   "dependencies": {
-    "bindings": "~1.2.0",
     "debug": "~0.8.1",
     "is-object": "~0.1.2",
-    "nan": "~1.0.0"
+    "nan": "~1.0.0",
+    "node-pre-gyp": "0.5.x"
   },
+  "bundledDependencies":["node-pre-gyp"],
   "devDependencies": {
     "mocha": "~1.14.0",
     "chai": "~1.8.1",
-    "semver": "~2.2.1"
+    "semver": "~2.2.1",
+    "aws-sdk": "~2.0.0-rc.15"
   },
   "repository": {
     "type": "git",
@@ -62,6 +64,7 @@
     "npm": "1"
   },
   "scripts": {
+    "install": "node-pre-gyp install --fallback-to-build",
     "build": "make rebuild",
     "test": "make test"
   },
@@ -70,5 +73,12 @@
       "type": "LGPL2.1",
       "url": "http://www.gnu.org/licenses/lgpl-2.1.txt"
     }
-  ]
+  ],
+  "binary": {
+    "module_name" : "native",
+    "module_path" : "./lib/binding/",
+    "host"        : "https://mapbox-node-binary.s3.amazonaws.com",
+    "remote_path" : "./{module_name}/v{version}",
+    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+  }
 }


### PR DESCRIPTION
Using [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) this change advances GeoIP to enable users to install the module without a compiler via a binary. This can make GeoIP much easier to install for javascript developers not familiar with native addons and it can make GeoIP much faster to install for devops teams.

Please see the node-pre-gyp docs (https://github.com/mapbox/node-pre-gyp#features) for details of how this works. And [this page](https://github.com/mapbox/node-pre-gyp/wiki/Modules-using-node-pre-gyp) for examples of other apps that are using node-pre-gyp to provide binaries.

Next steps:
- Decide on hosting location and AWS credentials
- Help provide first batch of binaries for Linux and OSX
- Discuss automation for binaries for upcoming releases
