### PR TITLE
fix continuing lookupSync bug

### DIFF
--- a/src/city.cc
+++ b/src/city.cc
@@ -64,10 +64,12 @@ NAN_METHOD(City::lookupSync) {
   City *c = ObjectWrap::Unwrap<City>(info.This());
 
   Local<Object> data = Nan::New<Object>();
-  static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
+  //static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
+  Nan::Utf8String host_cstr(info[0]);
   //printf("\nHost CStr is %s.\n", **host_cstr);
 
-  uint32_t ipnum = _GeoIP_lookupaddress(**host_cstr);
+  //uint32_t ipnum = _GeoIP_lookupaddress(**host_cstr);
+  uint32_t ipnum = _GeoIP_lookupaddress(*host_cstr);
   //printf("Ipnum is %d.", ipnum);
 
   if (ipnum == 0) {

--- a/src/city.cc
+++ b/src/city.cc
@@ -80,6 +80,7 @@ NAN_METHOD(City::lookupSync) {
 
   if (!record) {
     info.GetReturnValue().SetNull();
+    return;
   }
 
   if (record->country_code) {

--- a/src/city6.cc
+++ b/src/city6.cc
@@ -80,6 +80,7 @@ NAN_METHOD(City6::lookupSync) {
 
   if (!record) {
     info.GetReturnValue().SetNull();
+    return;
   }
 
   if (record->country_code) {

--- a/src/city6.cc
+++ b/src/city6.cc
@@ -66,9 +66,11 @@ NAN_METHOD(City6::lookupSync) {
   Local<Object> data = Nan::New<Object>();
   City6 *c = ObjectWrap::Unwrap<City6>(info.This());
 
-  static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
+  //static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
+  Nan::Utf8String host_cstr(info[0]);
   //Nan::Utf8String host_cstr(info[0]);
-  geoipv6_t ipnum_v6 = _GeoIP_lookupaddress_v6(**host_cstr);
+  //geoipv6_t ipnum_v6 = _GeoIP_lookupaddress_v6(**host_cstr);
+  geoipv6_t ipnum_v6 = _GeoIP_lookupaddress_v6(*host_cstr);
 
   if (__GEOIP_V6_IS_NULL(ipnum_v6)) {
     info.GetReturnValue().SetNull();

--- a/src/country.cc
+++ b/src/country.cc
@@ -66,9 +66,10 @@ NAN_METHOD(Country::lookupSync) {
 
   Local<Object> data = Nan::New<Object>();
 
-  static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
-  //Nan::Utf8String host_cstr(info[0]);
-  uint32_t ipnum = _GeoIP_lookupaddress(**host_cstr);
+  //static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
+  Nan::Utf8String host_cstr(info[0]);
+  //uint32_t ipnum = _GeoIP_lookupaddress(**host_cstr);
+  uint32_t ipnum = _GeoIP_lookupaddress(*host_cstr);
 
   if (ipnum <= 0) {
     info.GetReturnValue().SetNull();

--- a/src/country6.cc
+++ b/src/country6.cc
@@ -71,9 +71,10 @@ NAN_METHOD(Country6::lookupSync) {
 
   Local<Object> data = Nan::New<Object>();
 
-  static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
-  //Nan::Utf8String host_cstr(info[0]);
-  geoipv6_t ipnum_v6 = _GeoIP_lookupaddress_v6(**host_cstr);
+  //static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
+  Nan::Utf8String host_cstr(info[0]);
+  //geoipv6_t ipnum_v6 = _GeoIP_lookupaddress_v6(**host_cstr);
+  geoipv6_t ipnum_v6 = _GeoIP_lookupaddress_v6(*host_cstr);
 
   if (__GEOIP_V6_IS_NULL(ipnum_v6)) {
     info.GetReturnValue().SetNull();

--- a/src/region.cc
+++ b/src/region.cc
@@ -67,9 +67,10 @@ NAN_METHOD(Region::lookupSync) {
   Local<Object> data = Nan::New<Object>();
   Region *r = ObjectWrap::Unwrap<Region>(info.This());
 
-  static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
-  //Nan::Utf8String host_cstr(info[0]);
-  uint32_t ipnum = _GeoIP_lookupaddress(**host_cstr);
+  //static Nan::Utf8String *host_cstr = new Nan::Utf8String(info[0]);
+  Nan::Utf8String host_cstr(info[0]);
+  //uint32_t ipnum = _GeoIP_lookupaddress(**host_cstr);
+  uint32_t ipnum = _GeoIP_lookupaddress(*host_cstr);
 
   if (ipnum <= 0) {
     info.GetReturnValue().SetNull();

--- a/test/country.mocha.js
+++ b/test/country.mocha.js
@@ -62,6 +62,14 @@ describe('Country', function() {
             it('should can find location by ip address', function(done) {
                 var data = instance.lookupSync('8.8.8.8');
                 data.should.be.a('object');
+                data.country_code.should.equals('US');
+                setTimeout(done, 1);
+            });
+
+            it('should can find location by ip address', function(done) {
+                var data = instance.lookupSync('168.126.63.1');
+                data.should.be.a('object');
+                data.country_code.should.equals('KR');
                 setTimeout(done, 1);
             });
         });


### PR DESCRIPTION
bug fix for continuing lookupSync:
##### before
````
console.log(countryObj.lookupSync('8.8.8.8').country_code); // It should be 'US'. The output is 'US'.
console.log(countryObj.lookupSync('168.126.63.1').country_code); // It should be 'KR'. But, the output is 'US'.
````

I fixed nan codes and added test cases above.
##### after
````
console.log(countryObj.lookupSync('8.8.8.8').country_code);   // It should be 'US'. The output is 'US'.
console.log(countryObj.lookupSync('168.126.63.1').country_code); // It should be 'KR'. The output is 'KR'.
````

Thanks!