### PR TITLE
support nodejs 6.x (update nan, use node-gyp)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ iojs:
 nodejs:
 	@NODE_ENV=development bash ./cli/nodejs.sh
 rebuild: iojs install
-	@NODE_ENV=development ./node_modules/.bin/pangyp rebuild --verbose
+	@NODE_ENV=development ./node_modules/.bin/node-gyp rebuild --verbose
 bootstrap: install
 	@NODE_ENV=development sh ./cli/bootstrap.sh
 mem_test: install rebuild bootstrap

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "bindings": "~1.2.1",
     "debug": "~2.2.0",
     "is-object": "~1.0.1",
-    "nan": "~2.1.0",
-    "pangyp": "~2.3.0"
+    "nan": "~2.3.5",
+    "node-gyp": "~3.3.1"
   },
   "devDependencies": {
     "chai": "~3.2.0",

--- a/src/city.cc
+++ b/src/city.cc
@@ -25,8 +25,7 @@ void City::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("City").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("City").ToLocalChecked(), tpl->GetFunction());

--- a/src/city6.cc
+++ b/src/city6.cc
@@ -27,8 +27,7 @@ void City6::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("City6").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("City6").ToLocalChecked(), tpl->GetFunction());

--- a/src/country.cc
+++ b/src/country.cc
@@ -26,8 +26,7 @@ void Country::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("Country").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("Country").ToLocalChecked(), tpl->GetFunction());

--- a/src/country6.cc
+++ b/src/country6.cc
@@ -26,8 +26,7 @@ void Country6::Init(v8::Local<v8::Object> exports) {
     tpl->SetClassName(Nan::New("Country6").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-        Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+    Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
     constructor.Reset(tpl->GetFunction());
     exports->Set(Nan::New("Country6").ToLocalChecked(), tpl->GetFunction());

--- a/src/netspeed.cc
+++ b/src/netspeed.cc
@@ -26,8 +26,7 @@ void NetSpeed::Init(v8::Local<v8::Object> exports) {
     tpl->SetClassName(Nan::New("NetSpeed").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-        Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+    Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
     constructor.Reset(tpl->GetFunction());
     exports->Set(Nan::New("NetSpeed").ToLocalChecked(), tpl->GetFunction());

--- a/src/netspeedcell.cc
+++ b/src/netspeedcell.cc
@@ -26,8 +26,7 @@ void NetSpeedCell::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("NetSpeedCell").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("NetSpeedCell").ToLocalChecked(), tpl->GetFunction());

--- a/src/org.cc
+++ b/src/org.cc
@@ -25,8 +25,7 @@ void Org::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("Org").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("Org").ToLocalChecked(), tpl->GetFunction());;;

--- a/src/region.cc
+++ b/src/region.cc
@@ -27,8 +27,7 @@ void Region::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("Region").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("Region").ToLocalChecked(), tpl->GetFunction());


### PR DESCRIPTION
- update nan version (2.1.0 => 2.3.5)
- use node-gyp instead of pangyp(deprecated)
- tested on nodejs 4.4.5 & 6.2.2
